### PR TITLE
Plugin causes x-pack monitoring pipeline to fail 

### DIFF
--- a/lib/logstash/outputs/kinesis.rb
+++ b/lib/logstash/outputs/kinesis.rb
@@ -184,7 +184,7 @@ class LogStash::Outputs::Kinesis < LogStash::Outputs::Base
   def create_metrics_credentials_provider
     provider = AWSAuth.DefaultAWSCredentialsProviderChain.new()
     if @metrics_access_key and @metrics_secret_key
-      provider = BasicCredentialsProvider.new(AWSAuth.BasicAWSCredentials.new(@metrics_access_key, @metrics_secret_key))
+      provider = BasicKinesisCredentialsProvider.new(AWSAuth.BasicAWSCredentials.new(@metrics_access_key, @metrics_secret_key))
     end
     if @metrics_role_arn
       provider = create_sts_provider(provider, @metrics_role_arn)
@@ -209,7 +209,7 @@ class LogStash::Outputs::Kinesis < LogStash::Outputs::Base
   end
 end
 
-class BasicCredentialsProvider
+class BasicKinesisCredentialsProvider
   java_implements 'com.amazonaws.auth.AWSCredentialsProvider'
 
   def initialize(credentials)

--- a/lib/logstash/outputs/kinesis.rb
+++ b/lib/logstash/outputs/kinesis.rb
@@ -173,7 +173,7 @@ class LogStash::Outputs::Kinesis < LogStash::Outputs::Base
   def create_credentials_provider
     provider = AWSAuth.DefaultAWSCredentialsProviderChain.new()
     if @access_key and @secret_key
-      provider = BasicCredentialsProvider.new(AWSAuth.BasicAWSCredentials.new(@access_key, @secret_key))
+      provider = BasicKinesisCredentialsProvider.new(AWSAuth.BasicAWSCredentials.new(@access_key, @secret_key))
     end
     if @role_arn
       provider = create_sts_provider(provider, @role_arn)


### PR DESCRIPTION
When x-pack monitoring is enabled, logstash-output-kinesis causes the monitoring pipeline to fail with error message:

```[2017-07-05T22:22:48,722][ERROR][logstash.pipeline        ] Error registering plugin {:plugin=>"#<LogStash::OutputDelegator:0x14a3a5d9 @namespaced_metric=#<LogStash::Instrument::NamespacedNullMetric:0x35df2ac8 @metric=#<LogStash::Instrument::NullMetric:0x7f8fa04d @collector=#<LogStash::Instrument::Collector:0x4ae6a495 @agent=nil, @metric_store=#<LogStash::Instrument::MetricStore:0x43624d7d @store=#<Concurrent::Map:0x000000000635d4 entries=2 default_proc=nil>, @structured_lookup_mutex=#<Mutex:0xfa7a6b3>, @fast_lookup=#<Concurrent::Map:0x000000000635d8 entries=49 default_proc=nil>>>>, @namespace_name=[:stats, :pipelines, :\".monitoring-logstash\", :plugins, :outputs, :\"cca672ed2c05d7428765d23aed0d0a9692798c3b-2\"]>, @metric=#<LogStash::Instrument::NamespacedNullMetric:0x72153dee @metric=#<LogStash::Instrument::NullMetric:0x7f8fa04d @collector=#<LogStash::Instrument::Collector:0x4ae6a495 @agent=nil, @metric_store=#<LogStash::Instrument::MetricStore:0x43624d7d @store=#<Concurrent::Map:0x000000000635d4 entries=2 default_proc=nil>, @structured_lookup_mutex=#<Mutex:0xfa7a6b3>, @fast_lookup=#<Concurrent::Map:0x000000000635d8 entries=49 default_proc=nil>>>>, @namespace_name=[:stats, :pipelines, :\".monitoring-logstash\", :plugins, :outputs]>, @logger=#<LogStash::Logging::Logger:0x11ed3790 @logger=#<Java::OrgApacheLoggingLog4jCore::Logger:0x4f186a22>>, @strategy=#<LogStash::OutputDelegatorStrategies::Shared:0x38d54d @output=<LogStash::Outputs::ElasticSearch hosts=>[xxxxxxxx:9200], bulk_path=>\"/_xpack/monitoring/_bulk?system_id=logstash&system_api_version=2&interval=1s\", manage_template=>false, document_id=>\"cac81195-0b92-4249-a6d7-a1278e30f961\", document_type=>\"logstash\", index=>\"_data\", sniffing=>false, user=>\"xxxxxxx\", password=><password>, ssl=>true, id=>\"cca672ed2c05d7428765d23aed0d0a9692798c3b-2\", enable_metric=>true, codec=><LogStash::Codecs::Plain id=>\"plain_36b538fb-f402-498f-8ee6-9f299193c01f\", enable_metric=>true, charset=>\"UTF-8\">, workers=>1, template_name=>\"logstash\", template_overwrite=>false, idle_flush_time=>1, doc_as_upsert=>false, script_type=>\"inline\", script_lang=>\"painless\", script_var_name=>\"event\", scripted_upsert=>false, retry_initial_interval=>2, retry_max_interval=>64, retry_on_conflict=>1, action=>\"index\", ssl_certificate_verification=>true, sniffing_delay=>5, timeout=>60, pool_max=>1000, pool_max_per_route=>100, resurrect_delay=>5, validate_after_inactivity=>10000, http_compression=>false>>, @id=\"cca672ed2c05d7428765d23aed0d0a9692798c3b-2\", @metric_events=#<LogStash::Instrument::NamespacedNullMetric:0x4fc1cc11 @metric=#<LogStash::Instrument::NullMetric:0x7f8fa04d @collector=#<LogStash::Instrument::Collector:0x4ae6a495 @agent=nil, @metric_store=#<LogStash::Instrument::MetricStore:0x43624d7d @store=#<Concurrent::Map:0x000000000635d4 entries=2 default_proc=nil>, @structured_lookup_mutex=#<Mutex:0xfa7a6b3>, @fast_lookup=#<Concurrent::Map:0x000000000635d8 entries=49 default_proc=nil>>>>, @namespace_name=[:stats, :pipelines, :\".monitoring-logstash\", :plugins, :outputs, :\"cca672ed2c05d7428765d23aed0d0a9692798c3b-2\", :events]>, @output_class=LogStash::Outputs::ElasticSearch>", :error=>"wrong number of arguments calling `initialize` (0 for 1)"}```

Class BasicCredentialsProvider defined @ https://github.com/samcday/logstash-output-kinesis/blob/master/lib/logstash/outputs/kinesis.rb#L212 overwrites a class of the same name @ https://github.com/cheald/manticore/blob/master/lib/manticore/client.rb#L551

PR is tested and confirmed working
