### PR TITLE
Support sprintf-style stream names

### DIFF
--- a/lib/logstash/outputs/kinesis.rb
+++ b/lib/logstash/outputs/kinesis.rb
@@ -195,7 +195,7 @@ class LogStash::Outputs::Kinesis < LogStash::Outputs::Base
   def send_record(event, payload)
     begin
       event_blob = ByteBuffer::wrap(payload.to_java_bytes)
-      @producer.addUserRecord(@stream_name, event.get("[@metadata][partition_key]"), event_blob)
+      @producer.addUserRecord(event.sprintf(@stream_name), event.get("[@metadata][partition_key]"), event_blob)
     rescue => e
       @logger.warn("Error writing event to Kinesis", :exception => e)
     end

--- a/spec/outputs/kinesis_spec.rb
+++ b/spec/outputs/kinesis_spec.rb
@@ -43,6 +43,16 @@ describe LogStash::Outputs::Kinesis do
       output.close
     end
 
+    it "should support blank partition keys" do
+      expect_any_instance_of(KPL::KinesisProducer).to receive(:addUserRecord)
+        .with(anything, "-", anything)
+
+      output = LogStash::Outputs::Kinesis.new(config)
+      output.register
+      output.receive(sample_event)
+      output.close
+    end
+
     it "should support randomized partition keys" do
       expect_any_instance_of(KPL::KinesisProducer).to receive(:addUserRecord)
         .with(anything, /[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+/, anything)

--- a/spec/outputs/kinesis_spec.rb
+++ b/spec/outputs/kinesis_spec.rb
@@ -79,8 +79,10 @@ describe LogStash::Outputs::Kinesis do
     end
 
     it "should support fixed partition keys" do
+      # the partition key ends up being an empty string plus the first field
+      # we choose joined by a hyphen. this is a holdover from earlier versions
       expect_any_instance_of(KPL::KinesisProducer).to receive(:addUserRecord)
-        .with(anything, "foo", anything)
+        .with(anything, "-foo", anything)
 
       output = LogStash::Outputs::Kinesis.new(config.merge({
         "event_partition_keys" => ["[field1]", "[field2]"]

--- a/spec/outputs/kinesis_spec.rb
+++ b/spec/outputs/kinesis_spec.rb
@@ -13,6 +13,7 @@ describe LogStash::Outputs::Kinesis do
   let(:sample_event) {
     LogStash::Event.new({
       "message" => "hello",
+      'stream_name' => 'my_stream',
       "field1"  => "foo",
       "field2"  => "bar"
     })
@@ -38,6 +39,18 @@ describe LogStash::Outputs::Kinesis do
       expect_any_instance_of(KPL::KinesisProducer).to receive(:addUserRecord)
 
       output = LogStash::Outputs::Kinesis.new (config)
+      output.register
+      output.receive(sample_event)
+      output.close
+    end
+
+    it "should support Event#sprintf placeholders in stream_name" do
+      expect_any_instance_of(KPL::KinesisProducer).to receive(:addUserRecord)
+        .with("my_stream", anything, anything)
+
+      output = LogStash::Outputs::Kinesis.new(config.merge({
+        "stream_name" => "%{stream_name}",
+      }))
       output.register
       output.receive(sample_event)
       output.close


### PR DESCRIPTION
This PR allows the Kinesis stream name to be dynamic based on the event. This implementation was modeled off Kafka's topic selection, IIRC (I implemented this a long time ago and we've actually been running it for several months).

In our case this allowed us to go from 10 kinesis outputs for 10 streams to 1.

Example config: this will convert the stream name based on the `resource_type` field in each event.

```
output {
  kinesis {
    # ...
    stream_name => "%{resource_type}-updates"
  }
}
```
