### PR TITLE
Bump KPL to 0.12.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ This is being tracked in awslabs/amazon-kinesis-producer#17. This log message se
 
 ## Contributions
 
-Are more than welcome. See [CONTRIBUTING.MD](CONTRIBUTING.MD)
+Are more than welcome. See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 
 ## License

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.amazonaws:amazon-kinesis-producer:0.12.5'
+    compile 'com.amazonaws:amazon-kinesis-producer:0.12.6'
     compile 'com.amazonaws:aws-java-sdk-sts:1.11.128'
 }
 

--- a/vendor/jar-dependencies/runtime-jars/amazon-kinesis-producer-0.12.5.jar
+++ b/vendor/jar-dependencies/runtime-jars/amazon-kinesis-producer-0.12.5.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d209c7d87be21177e696c8093ddd4a2b3376d6c632ed7975cc723a7b9ebd9643
-size 16055172

--- a/vendor/jar-dependencies/runtime-jars/amazon-kinesis-producer-0.12.6.jar
+++ b/vendor/jar-dependencies/runtime-jars/amazon-kinesis-producer-0.12.6.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c697ce72514c36aabe552ee4e561688c467af67e36f3c735cff00a78fd80449
+size 21384792


### PR DESCRIPTION
Amazon is discontinuing KPL older than 0.12.6 on 9th of Feb: https://docs.aws.amazon.com/streams/latest/dev/kinesis-kpl-upgrades.html