### PR TITLE
Adding log4j binding for slf4j to get KPL logs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,17 @@ bundle exec rake
 rake
 ```
 
+### Building gem
+
+```
+gem build logstash-output-kinesis
+```
+
+### Testing locally built gem
+```
+bin/logstash-plugin install --local /path/to/logstash-output-kinesis-5.1.1-java.gem
+```
+
 ### Updating KPL
 
 Change the dependency version in `build.gradle`, and then run `gradle copylibs`. Make sure to check in all the updated JARs!

--- a/README.md
+++ b/README.md
@@ -161,6 +161,22 @@ output {
 }
 ```
 
+### Logging configuration
+
+The underlying KPL uses SLF4J for logging and binding for Log4j (used by Logstash) is included in the plugin package. Thus the logging levels can be controlled with the `log4j2.properties` file provided by Logstash.
+
+As the KPL might be too noisy with `INFO` level, you might want to dial it down by following configuration in `log4j2.properties`:
+
+```
+...
+logger.kinesis.name = com.amazonaws.services.kinesis
+logger.kinesis.level = WARN
+logger.kinesis.additivity = false
+logger.kinesis.appenderRef.console.ref = console
+...
+
+``` 
+
 ## Known Issues
 
 ### Alpine Linux is not supported

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@ repositories {
 dependencies {
     compile 'com.amazonaws:amazon-kinesis-producer:0.12.6'
     compile 'com.amazonaws:aws-java-sdk-sts:1.11.128'
+    compile ('org.apache.logging.log4j:log4j-slf4j-impl:2.6.2' ) {
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
 }
 
 task copyLibs(type: Copy) {

--- a/vendor/jar-dependencies/runtime-jars/log4j-slf4j-impl-2.6.2.jar
+++ b/vendor/jar-dependencies/runtime-jars/log4j-slf4j-impl-2.6.2.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45bd8c9780cef584ef25ba1d80fa1e241f5aa9b209b283fe6ff4d929153e5c73
+size 22927


### PR DESCRIPTION
This PR addresses the issue of missing logs from the KPL library. Not sure if this was the best way to introduce the slf4j binding, but feel free to comment.